### PR TITLE
Raised dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,8 +9,8 @@ HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 
 [compat]
-CodecZlib = "0.6.0"
-HTTP = "0.8.8"
+CodecZlib = "0.6.0, 0.7.0"
+HTTP = "0.8.8, 0.9.0"
 JSON = "0.21.0"
 julia = "1"
 


### PR DESCRIPTION
This allows people to use this repo with newer dependencies.
Everything should work as it does not seem to use functions or structures which are present in `HTTP@0.8` but not in `HTTP@0.9`.
Fixes #15 .
Please, label this PR with `hacktoberfest-accepted`.
Thanks.